### PR TITLE
Trust set symbol & decimals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-token-tracker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A module for tracking Ethereum token balances over block changes.",
   "main": "index.js",
   "scripts": {

--- a/test/human-standard-token.js
+++ b/test/human-standard-token.js
@@ -16,6 +16,9 @@ const source = fs.readFileSync(__dirname + '/contracts/Token.sol').toString();
 const compiled = solc.compile(source, 1)
 const HumanStandardDeployer = compiled.contracts[':HumanStandardToken']
 
+const SET_SYMBOL = 'DBX'
+const EXPECTED_SYMBOL = 'EXP'
+
 let addresses = []
 let token, tokenAddress, tracked
 
@@ -38,7 +41,7 @@ test('HumanStandardToken publishing token & checking balance', function (t) {
   const humanStandardToken = HumanStandardToken.new('1000',
                                                     'DanBucks',
                                                     '2', // decimals
-                                                    'DBX')
+                                                    SET_SYMBOL)
   .then((txHash) => {
     t.ok(txHash, 'publishes a txHash')
 
@@ -75,6 +78,7 @@ test('HumanStandardToken balances are tracked', function (t) {
     tokens: [
       {
         address: tokenAddress,
+        symbol: EXPECTED_SYMBOL,
       }
     ],
   })
@@ -93,7 +97,7 @@ test('HumanStandardToken balances are tracked', function (t) {
     return a
   })
   .then(() => {
-    t.equal(tracked.symbol, 'DBX', 'symbol retrieved')
+    t.equal(tracked.symbol, EXPECTED_SYMBOL, 'symbol cached')
     t.equal(tracked.address, tokenAddress, 'token address set')
     t.equal(tracked.balance.toString(10), '890', 'tokens sent')
     t.equal(tracked.decimals.toString(), '2', 'decimals received')
@@ -138,7 +142,7 @@ test('HumanStandardToken balance changes are emitted', function (t) {
       return t.equal(tracked.string, '8.90', 'initial balance loaded from last test')
     }
 
-    t.equal(tracked.symbol, 'DBX', 'symbol retrieved')
+    t.equal(tracked.symbol, SET_SYMBOL, 'symbol retrieved')
     t.equal(tracked.string, '7.90', 'balance updated')
     tokenTracker.stop()
     t.end()

--- a/test/simple-token.js
+++ b/test/simple-token.js
@@ -121,7 +121,7 @@ test('StandardToken balances are tracked', function (t) {
 
 })
 
-test('StandardToken balance changes are emitted', function (t) {
+test('StandardToken balance changes are emitted and symbol fetched', function (t) {
 
   var tokenTracker = new TokenTracker({
     userAddress: addresses[0],

--- a/token.js
+++ b/token.js
@@ -7,7 +7,7 @@ class Token {
     const { address, symbol, balance, decimals, contract, owner } = opts
     this.isLoading = !address || !symbol || !balance || !decimals
     this.address = address || '0x0'
-    this.symbol  = symbol || 'TKN'
+    this.symbol  = symbol
     this.balance = new BN(balance || '0', 16)
     this.decimals = decimals ? new BN(decimals) : undefined
     this.owner = owner
@@ -21,9 +21,9 @@ class Token {
 
   async update() {
     const results = await Promise.all([
-      this.updateSymbol(),
+      this.symbol || this.updateSymbol(),
       this.updateBalance(),
-      this.updateDecimals(),
+      this.decimals || this.updateDecimals(),
     ])
     this.isLoading = false
     return results
@@ -45,9 +45,8 @@ class Token {
 
   async updateSymbol() {
     const symbol = await this.updateValue('symbol')
-    if (symbol) {
-      this.symbol = symbol
-    }
+    console.dir({ symbol })
+    this.symbol = symbol || 'TKN'
     return this.symbol
   }
 

--- a/token.js
+++ b/token.js
@@ -45,7 +45,6 @@ class Token {
 
   async updateSymbol() {
     const symbol = await this.updateValue('symbol')
-    console.dir({ symbol })
     this.symbol = symbol || 'TKN'
     return this.symbol
   }


### PR DESCRIPTION
If constructor includes symbol or decimals, do not query for those.
After querying for symbol or decimals, do not query for them again.